### PR TITLE
Fix controls not "sticking" to mouse

### DIFF
--- a/_extensions/imagemover/imagemover.js
+++ b/_extensions/imagemover/imagemover.js
@@ -120,9 +120,16 @@ function setupDraggableImage(img) {
 
   function getClientCoordinates(e) {
     const isTouch = e.type.startsWith('touch');
+
+    // revealjs scales this .slides container element so that
+    // the slide fits completely in the viewport. We have to
+    // adjust the mouse/touch positions by this scaling.
+    const slidesContainerEl = document.querySelector('.slides')
+    const scale =  window.getComputedStyle(slidesContainerEl).getPropertyValue('--slide-scale')
+
     return {
-      clientX: isTouch ? e.touches[0].clientX : e.clientX,
-      clientY: isTouch ? e.touches[0].clientY : e.clientY
+      clientX: (isTouch ? e.touches[0].clientX : e.clientX)/scale,
+      clientY: (isTouch ? e.touches[0].clientY : e.clientY)/scale
     };
   }
 


### PR DESCRIPTION
While playing around with the extension, I noticed that the drag points of an image don't "stick" to your mouse (they sometimes lag behind or zoom ahead), depending on the aspect ratio of your preview's viewport. This happened both when resizing and when moving.

After looking into it, I saw that revealjs scales the slides so they are always fully contained in the viewport. The problem was that the mouse coordinates during dragging and moving did not account for the scaling of the slide.

Revealjs gives an easy way to get the scale of the slides: a css variable called `--slide-scale`

| Before | After |
|---|---|
| ![Kapture 2025-08-19 at 14 37 19](https://github.com/user-attachments/assets/98a5e206-fcb0-4e19-82b0-5fb04fd552d2) | <video src="https://github.com/user-attachments/assets/affebfd6-b65c-4de8-969a-2edc2c8430c4"> |


